### PR TITLE
Removal of useless reference and dereference

### DIFF
--- a/src/request_maker.rs
+++ b/src/request_maker.rs
@@ -16,8 +16,8 @@ fn make_request() -> Result<HashMap<String, serde_json::Value>, Box<dyn std::err
 
 // Transforming API result to i64 temperature (° Celsius)
 pub fn get_temp() -> Result<String, Box<dyn Error>> {
-    let temp = &make_request()?["main"]["temp"]
+    let temp = make_request()?["main"]["temp"]
         .as_f64()
         .ok_or("Cannot convert temperature")?;
-    Ok((*temp as i64).to_string())
+    Ok((temp as i64).to_string())
 }


### PR DESCRIPTION
My idea for setting up user API key and location : use a setup program / script which is separate from the systray app itself, which will set the variables in the OS environment variables:

![image](https://user-images.githubusercontent.com/37193744/90544097-edd13700-e186-11ea-93a3-b1368e9f062c.png)
