### PR TITLE
Some minor cosmetic & package metadata changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "temp_tray-rs"
 version = "0.2.0"
 authors = ["Werner1201 <werner.romling@unigranrio.br>", "Nicolas BAUW <nbauw@hotmail.com>"]
 edition = "2018"
+repository = "https://github.com/Werner1201/weather_tray-rs"
+keywords = ["open", "weather", "temperature", "systray"]
+description = "Systray application to see current temperature in selected location."
+readme = "README.md"
+default-run = "temp_tray-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/bin/setup/main.rs
+++ b/src/bin/setup/main.rs
@@ -11,7 +11,7 @@ fn main() {
 
 fn construct_gui() {
     let gui_window = App::default();
-    let mut wind = Window::new(100, 100, 400, 300, "Hello from rust");
+    let mut wind = Window::new(100, 100, 400, 300, "Temperature Systray Setup");
     let _get_key_label = Frame::new(150, 30, 100, 20, "To Obtain your key acess:");
     let mut link = Button::new(
         150,


### PR DESCRIPTION
- I've renamed the setup window title (it was a generic one)
- I've added package metadata (repo link, keywords, and so on) and most notably the default executable run by the "cargo run" command which is now the systray app. To run the setup, the command is cargo run --bin setup

cargo build will build both executables.
Note : don't know if you are aware of that, just in case a reminder : to build optimized non-dev builds, the command is cargo build -- release

I don't know if you noticed, I increased the version in cargo.toml to 0.2 a few days ago, since there were some changes in program logic.